### PR TITLE
tox: ignore pylint w707 "reraise with from"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,12 +33,13 @@ commands = black --skip-string-normalization .
 
 [testenv:linters]
 skip_install = true
-deps = flake8
-       flake8-colors
-       black
+deps =
+    flake8
+    flake8-colors
+    black
 commands =
-  black --skip-string-normalization --check .
-  flake8
+    black --skip-string-normalization --check .
+    flake8
 
 [testenv:pylint]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -53,8 +53,9 @@ whitelist_externals =
 [flake8]
 # E501: line too long (80 chars)
 # W503: line break before binary operator
+# W707: reraise with "from"
 exclude = .tox,.eggs
 show-source = true
-ignore = E501, W503
+ignore = E501, W503, W707
 max-line-length = 99
 application-import-names = wazo_stat


### PR DESCRIPTION
Why:

* Jenkins is unstable because of pylint warning