### PR TITLE
test: use mock from unittest library

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
-mock
 pytest

--- a/wazo_stat/tests/test_agent.py
+++ b/wazo_stat/tests/test_agent.py
@@ -1,14 +1,12 @@
-# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
 from datetime import datetime as dt
 from datetime import timedelta
+from unittest.mock import ANY, Mock, patch
 
-from mock import ANY
-from mock import Mock
-from mock import patch
 from xivo_dao.helpers.db_manager import daosession
 
 from wazo_stat import agent

--- a/wazo_stat/tests/test_core.py
+++ b/wazo_stat/tests/test_core.py
@@ -1,9 +1,11 @@
-# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 import datetime
-from mock import ANY, patch, sentinel
+
+from unittest.mock import ANY, patch, sentinel
+
 from wazo_stat import core
 from wazo_stat.core import _ERASE_TIME_WHEN_STARTING
 

--- a/wazo_stat/tests/test_queue.py
+++ b/wazo_stat/tests/test_queue.py
@@ -1,10 +1,10 @@
-# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 from xivo_dao.helpers.db_manager import daosession
 
 from wazo_stat import queue


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package