### PR TITLE
Add dependency on sqlalchemy-utils for dao

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
 https://github.com/wazo-platform/xivo-dao/archive/master.zip
 https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
 sqlalchemy==1.3.22  # from xivo-dao
+sqlalchemy-utils==0.36.8  # from xivo-dao
 psycopg2-binary==2.8.6  # from xivo-dao
 pyyaml==5.3.1 # from xivo-lib-python
 requests==2.25.1  # from wazo-*-client


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-dao/pull/207