### PR TITLE
queue: checks and logging to fill_abandoned_call and fill_timeout_call

### DIFF
--- a/wazo_stat/queue.py
+++ b/wazo_stat/queue.py
@@ -32,7 +32,7 @@ def fill_timeout_call(dao_sess, start, end):
     for call in timeout_calls:
         if not call['waittime']:
             logger.error(
-                "Abandoned call (callid=%s) missing waittime value, skipping",
+                "Timeout call (callid=%s) missing waittime value, skipping",
                 call['callid'],
             )
             continue

--- a/wazo_stat/queue.py
+++ b/wazo_stat/queue.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -16,6 +16,12 @@ logger = logging.getLogger(__name__)
 def fill_abandoned_call(dao_sess, start, end):
     abandoned_calls = queue_log_dao.get_queue_abandoned_call(dao_sess, start, end)
     for call in abandoned_calls:
+        if not call['waittime']:
+            logger.error(
+                "Abandoned call (callid=%s) missing waittime value, skipping",
+                call['callid'],
+            )
+            continue
         stat_call_on_queue_dao.add_abandoned_call(
             dao_sess, call['callid'], call['time'], call['queue_name'], call['waittime']
         )
@@ -24,6 +30,12 @@ def fill_abandoned_call(dao_sess, start, end):
 def fill_timeout_call(dao_sess, start, end):
     timeout_calls = queue_log_dao.get_queue_timeout_call(dao_sess, start, end)
     for call in timeout_calls:
+        if not call['waittime']:
+            logger.error(
+                "Abandoned call (callid=%s) missing waittime value, skipping",
+                call['callid'],
+            )
+            continue
         stat_call_on_queue_dao.add_timeout_call(
             dao_sess, call['callid'], call['time'], call['queue_name'], call['waittime']
         )

--- a/wazo_stat/tests/test_queue.py
+++ b/wazo_stat/tests/test_queue.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
@@ -28,6 +28,7 @@ class TestQueue(unittest.TestCase):
             "%Y-%m-%d %H:%M:%S.%f"
         )
         callid = '1234567.890'
+        callid2 = '1234567.891'
         waittime = 3
         mock_get_abandoned_call.return_value = [
             {
@@ -36,7 +37,15 @@ class TestQueue(unittest.TestCase):
                 'time': d1,
                 'callid': callid,
                 'waittime': waittime,
-            }
+            },
+            # should be ignored
+            {
+                'queue_name': self._queue_name,
+                'event': 'abandoned',
+                'time': d1,
+                'callid': callid2,
+                'waittime': '',
+            },
         ]
 
         queue.fill_abandoned_call(self._dao_sess, d1, d2)
@@ -53,6 +62,7 @@ class TestQueue(unittest.TestCase):
             "%Y-%m-%d %H:%M:%S.%f"
         )
         callid = '1234567.890'
+        callid2 = '1234567.891'
         waittime = 7
         mock_get_timeout_call.return_value = [
             {
@@ -61,7 +71,15 @@ class TestQueue(unittest.TestCase):
                 'time': d1,
                 'callid': callid,
                 'waittime': waittime,
-            }
+            },
+            # should be ignored
+            {
+                'queue_name': self._queue_name,
+                'event': 'timeout',
+                'time': d1,
+                'callid': callid2,
+                'waittime': '',
+            },
         ]
 
         queue.fill_timeout_call(self._dao_sess, d1, d2)


### PR DESCRIPTION
to ignore calls with missing waittime value
why: resiliency

Depends on: https://github.com/wazo-platform/xivo-dao/pull/271