### PR TITLE
WAZO-3981-sqlalchemy-warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ env_list = py311, linters
 no_package = true
 
 [testenv]
+set_env =
+    SQLALCHEMY_WARN_20=1
 commands =
     pytest --junitxml=unit-tests.xml --cov=wazo_stat --cov-report term --cov-report xml:coverage.xml wazo_stat
 deps =


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set SQLALCHEMY_WARN_20=1 in tox testenv to surface SQLAlchemy 2.0 warnings during pytest runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54342b6a60d1ad189b49cbfd68de2317fdaaef86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->