### PR TITLE
[ITEM-295] Agent queues statistics

### DIFF
--- a/wazo_stat/agent.py
+++ b/wazo_stat/agent.py
@@ -1,10 +1,11 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 from datetime import timedelta
 
 from xivo_dao import queue_log_dao, stat_agent_periodic_dao, stat_dao
+from xivo_dao.alchemy.stat_queue import StatQueue
 
 from wazo_stat import time_utils
 
@@ -52,9 +53,31 @@ def insert_periodic_stat(dao_sess, start, end):
         periodic_stats_wrapup,
     )
 
+    queue_id_cache: dict[str, int | None] = {}
     for period, stats in periodic_stats.items():
-        stat_agent_periodic_dao.insert_stats(dao_sess, stats, period)
+        resolved = _resolve_queue_names(dao_sess, stats, queue_id_cache)
+        stat_agent_periodic_dao.insert_stats(dao_sess, resolved, period)
     dao_sess.flush()
+
+
+def _resolve_queue_names(dao_sess, stats, cache):
+    resolved = {}
+    for (agent_id, queue_name), times in stats.items():
+        if queue_name is None:
+            resolved[(agent_id, None)] = times
+            continue
+        if queue_name not in cache:
+            cache[queue_name] = _get_queue_id_by_name(dao_sess, queue_name)
+        stat_queue_id = cache[queue_name]
+        if stat_queue_id is None:
+            continue
+        resolved[(agent_id, stat_queue_id)] = times
+    return resolved
+
+
+def _get_queue_id_by_name(dao_sess, queue_name: str) -> int | None:
+    row = dao_sess.query(StatQueue.id).filter_by(name=queue_name, deleted=False).first()
+    return row.id if row else None
 
 
 def remove_after_start(dao_sess, date):

--- a/wazo_stat/agent.py
+++ b/wazo_stat/agent.py
@@ -68,6 +68,12 @@ def _resolve_queue_names(dao_sess, stats, cache):
             continue
         if queue_name not in cache:
             cache[queue_name] = _get_queue_id_by_name(dao_sess, queue_name)
+            if cache[queue_name] is None:
+                logger.debug(
+                    'Queue "%s" not found in stat_queue: '
+                    'skipping per-queue agent stats',
+                    queue_name,
+                )
         stat_queue_id = cache[queue_name]
         if stat_queue_id is None:
             continue

--- a/wazo_stat/tests/test_agent.py
+++ b/wazo_stat/tests/test_agent.py
@@ -154,6 +154,52 @@ class TestAgent(unittest.TestCase):
         }
         mock_insert_stats.assert_any_call(ANY, expected_resolved, period)
 
+    @patch('wazo_stat.agent._get_queue_id_by_name')
+    @patch('xivo_dao.stat_agent_periodic_dao.insert_stats')
+    @patch('xivo_dao.stat_dao.get_login_intervals_in_range')
+    @patch('xivo_dao.stat_dao.get_pause_intervals_in_range')
+    @patch('xivo_dao.queue_log_dao.get_wrapup_times')
+    def test_insert_periodic_stat_fans_out_per_queue_pause(
+        self,
+        mock_get_wrapup_times,
+        mock_get_pause_intervals_in_range,
+        mock_get_login_intervals_in_range,
+        mock_insert_stats,
+        mock_get_queue_id_by_name,
+    ):
+        agent_id = 42
+        queue_name = 'sales'
+        stat_queue_id = 7
+        period = dt(2012, 1, 1, 1)
+
+        mock_get_queue_id_by_name.side_effect = lambda sess, name: (
+            stat_queue_id if name == queue_name else None
+        )
+
+        pause_output = {
+            period: {
+                (agent_id, None): {'pause_time': timedelta(minutes=5)},
+                (agent_id, queue_name): {'pause_time': timedelta(minutes=3)},
+            },
+        }
+
+        mock_get_login_intervals_in_range.return_value = {}
+        mock_get_pause_intervals_in_range.return_value = {}
+        mock_get_wrapup_times.return_value = {}
+
+        with patch.object(agent, 'AgentTimeComputer') as mock_computer_cls:
+            computer = mock_computer_cls.return_value
+            computer.compute_login_time_in_period.return_value = {}
+            computer.compute_pause_time_in_period.return_value = pause_output
+
+            agent.insert_periodic_stat(_session(), period, period + ONE_HOUR)
+
+        expected_resolved = {
+            (agent_id, None): {'pause_time': timedelta(minutes=5)},
+            (agent_id, stat_queue_id): {'pause_time': timedelta(minutes=3)},
+        }
+        mock_insert_stats.assert_any_call(ANY, expected_resolved, period)
+
 
 class TestAgentLoginTimeComputer(unittest.TestCase):
     def test__add_time_to_agent_in_period(self):

--- a/wazo_stat/tests/test_agent.py
+++ b/wazo_stat/tests/test_agent.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -33,44 +33,46 @@ class TestAgent(unittest.TestCase):
         agent_id_1 = 12
         agent_id_2 = 13
         login = {
-            agent_id_1: [
+            (agent_id_1, None): [
                 (dt(2012, 1, 1, 1, 5), dt(2012, 1, 1, 1, 15)),
                 (dt(2012, 1, 1, 1, 20), dt(2012, 1, 1, 2, 20)),
             ],
-            agent_id_2: [
+            (agent_id_2, None): [
                 (dt(2012, 1, 1, 1), dt(2012, 1, 1, 5)),
             ],
         }
         pause = {
-            agent_id_1: [
+            (agent_id_1, None): [
                 (dt(2012, 1, 1, 1, 35), dt(2012, 1, 1, 1, 40)),
             ],
-            agent_id_2: [
+            (agent_id_2, None): [
                 (dt(2012, 1, 1, 2), dt(2012, 1, 1, 3)),
             ],
         }
         output_stats = {
             dt(2012, 1, 1, 1): {
-                agent_id_1: {
+                (agent_id_1, None): {
                     'login_time': timedelta(minutes=50),
                     'pause_time': timedelta(minutes=5),
                 },
-                agent_id_2: {'login_time': ONE_HOUR},
+                (agent_id_2, None): {'login_time': ONE_HOUR},
             },
             dt(2012, 1, 1, 2): {
-                agent_id_1: {'login_time': timedelta(minutes=20)},
-                agent_id_2: {'login_time': ONE_HOUR, 'pause_time': ONE_HOUR},
+                (agent_id_1, None): {'login_time': timedelta(minutes=20)},
+                (agent_id_2, None): {'login_time': ONE_HOUR, 'pause_time': ONE_HOUR},
             },
             dt(2012, 1, 1, 3): {
-                agent_id_1: {'wrapup_time': timedelta(seconds=15)},
-                agent_id_2: {'login_time': ONE_HOUR},
+                (agent_id_1, None): {'wrapup_time': timedelta(seconds=15)},
+                (agent_id_2, None): {'login_time': ONE_HOUR},
             },
             dt(2012, 1, 1, 4): {
-                agent_id_2: {'login_time': ONE_HOUR},
+                (agent_id_2, None): {'login_time': ONE_HOUR},
             },
         }
         wrapups = {
-            dt(2012, 1, 1, 3): {agent_id_1: {'wrapup_time': timedelta(seconds=15)}},
+            dt(2012, 1, 1, 3): {
+                (agent_id_1, None): {'wrapup_time': timedelta(seconds=15)},
+            },
         }
         start = dt(2012, 1, 1, 1)
         end = dt(2012, 1, 1, 4)
@@ -86,6 +88,71 @@ class TestAgent(unittest.TestCase):
 
         for period_start, agents_stats in output_stats.items():
             mock_insert_stats.assert_any_call(ANY, agents_stats, period_start)
+
+    @patch('wazo_stat.agent._get_queue_id_by_name')
+    @patch('xivo_dao.stat_agent_periodic_dao.insert_stats')
+    @patch('xivo_dao.stat_dao.get_login_intervals_in_range')
+    @patch('xivo_dao.stat_dao.get_pause_intervals_in_range')
+    @patch('xivo_dao.queue_log_dao.get_wrapup_times')
+    def test_insert_periodic_stat_resolves_queue_names(
+        self,
+        mock_get_wrapup_times,
+        mock_get_pause_intervals_in_range,
+        mock_get_login_intervals_in_range,
+        mock_insert_stats,
+        mock_get_queue_id_by_name,
+    ):
+        agent_id = 42
+        queue_name = 'sales'
+        stat_queue_id = 7
+        period = dt(2012, 1, 1, 1)
+
+        mock_get_queue_id_by_name.side_effect = lambda sess, name: (
+            stat_queue_id if name == queue_name else None
+        )
+
+        login_output = {
+            period: {
+                (agent_id, None): {'login_time': ONE_HOUR},
+                (agent_id, queue_name): {'login_time': timedelta(minutes=30)},
+                (agent_id, 'deleted_queue'): {'login_time': timedelta(minutes=5)},
+            },
+        }
+        pause_output = {
+            period: {
+                (agent_id, None): {'pause_time': timedelta(minutes=2)},
+            },
+        }
+        wrapups = {
+            period: {
+                (agent_id, None): {'wrapup_time': timedelta(seconds=10)},
+                (agent_id, queue_name): {'wrapup_time': timedelta(seconds=10)},
+            },
+        }
+
+        mock_get_login_intervals_in_range.return_value = {}
+        mock_get_pause_intervals_in_range.return_value = {}
+        mock_get_wrapup_times.return_value = wrapups
+
+        with patch.object(agent, 'AgentTimeComputer') as mock_computer_cls:
+            computer = mock_computer_cls.return_value
+            computer.compute_login_time_in_period.return_value = login_output
+            computer.compute_pause_time_in_period.return_value = pause_output
+
+            agent.insert_periodic_stat(_session(), period, period + ONE_HOUR)
+
+        expected_resolved = {
+            (agent_id, None): {
+                'login_time': ONE_HOUR,
+                'pause_time': timedelta(minutes=2),
+                'wrapup_time': timedelta(seconds=10),
+            },
+            (agent_id, stat_queue_id): {
+                'login_time': timedelta(minutes=30),
+                'wrapup_time': timedelta(seconds=10),
+            },
+        }
+        mock_insert_stats.assert_any_call(ANY, expected_resolved, period)
 
 
 class TestAgentLoginTimeComputer(unittest.TestCase):


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/345

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what gets written to agent periodic stats and depends on xivo-dao; missing queue mappings silently omit per-queue data.
> 
> **Overview**
> **Per-queue agent periodic stats** are now persisted by resolving queue **names** to `stat_queue` IDs before calling `insert_stats`, while **agent-wide** rows still use `(agent_id, None)`.
> 
> `insert_periodic_stat` runs merged login/pause/wrapup stats through `_resolve_queue_names`, which caches lookups via `_get_queue_id_by_name` on non-deleted `StatQueue` rows. Entries for unknown or missing queues are **dropped** (debug log only), so only queues present in `stat_queue` get per-queue agent metrics.
> 
> Tests were updated to use `(agent_id, queue_name)` keys in fixtures and add coverage for name→ID resolution (including skipping deleted queues) and separate global vs per-queue pause rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af8916b6cce51f607ccc7553eee509843d52970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->