### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/etc/wazo-stat/config.yml
+++ b/etc/wazo-stat/config.yml
@@ -17,8 +17,7 @@ db_uri: postgresql://asterisk:proformatique@localhost/asterisk?application_name=
 # wazo-auth connection settings.
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false
 
 # wazo-confd connection settings

--- a/wazo_stat/config.py
+++ b/wazo_stat/config.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.chain_map import ChainMap
@@ -13,8 +13,7 @@ _DEFAULT_CONFIG = {
     'confd': {'host': 'localhost', 'port': 9486, 'prefix': None, 'https': False},
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-stat-key.yml',
     },


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auth connectivity depends on coordinated deployment with wazo-nginx and wazo-auth; merging early breaks internal authentication with 404s.
> 
> **Overview**
> **wazo-stat** internal **wazo-auth** traffic is retargeted from the direct service port (**9497**) to the nginx internal listener on **`localhost:80`**, in both shipped **`etc/wazo-stat/config.yml`** and Python **`_DEFAULT_CONFIG`** so defaults stay aligned when YAML is layered on top.
> 
> The explicit **`auth.prefix`** entry is removed so the client uses its built-in **`/api/auth`** path. **wazo-confd** settings are unchanged.
> 
> This must ship **after** the nginx internal entry point and matching wazo-auth location are deployed; otherwise internal auth requests can **404**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5483df00ec55d74847213f12573e778531194e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->